### PR TITLE
Add InitializeTokenMetadata and UpdateField instructions

### DIFF
--- a/programs/token/src/extensions/metadata.rs
+++ b/programs/token/src/extensions/metadata.rs
@@ -156,7 +156,7 @@ impl Extension for TokenMetadata<'_> {
 }
 
 // Instructions
-pub struct InitializeTokenMetadata<'a> {
+pub struct InitializeTokenMetadata<'a, const BUF_SIZE: usize> {
     /// The mint that this metadata pointer is associated with
     pub metadata: &'a AccountInfo,
     /// The authority that can sign to update the metadata
@@ -174,7 +174,7 @@ pub struct InitializeTokenMetadata<'a> {
     pub uri: &'a str,
 }
 
-impl InitializeTokenMetadata<'_> {
+impl<const BUF_SIZE: usize> InitializeTokenMetadata<'_, BUF_SIZE> {
     #[inline(always)]
     pub fn invoke(&self) -> ProgramResult {
         self.invoke_signed(&[])
@@ -190,8 +190,7 @@ impl InitializeTokenMetadata<'_> {
         // -  [16+x1+x2..20+x1+x2] u32: uri length (x3)
         // -  [20+x1+x2..20+x1+x2+x3][u8]: uri string
 
-        // Allocate a buffer with max possible data length.
-        let mut buf = [UNINIT_BYTE; 995];
+        let mut buf = [UNINIT_BYTE; BUF_SIZE];
         let mut offset: usize = 0;
 
         // Set 8-byte discriminator.
@@ -264,7 +263,7 @@ impl Field<'_> {
     }
 }
 
-pub struct UpdateField<'a> {
+pub struct UpdateField<'a, const BUF_SIZE: usize> {
     /// The mint that this metadata pointer is associated with
     pub metadata: &'a AccountInfo,
     /// The authority that can sign to update the metadata
@@ -275,7 +274,7 @@ pub struct UpdateField<'a> {
     pub value: &'a str,
 }
 
-impl UpdateField<'_> {
+impl<const BUF_SIZE: usize> UpdateField<'_, BUF_SIZE> {
     #[inline(always)]
     pub fn invoke(&self) -> ProgramResult {
         self.invoke_signed(&[])
@@ -295,8 +294,7 @@ impl UpdateField<'_> {
         // -  [9..13] u32: value length (x1)
         // -  [13..13+x1] [u8]: value string
 
-        // Allocate a buffer with max possible data length.
-        let mut buf = [UNINIT_BYTE; 995];
+        let mut buf = [UNINIT_BYTE; BUF_SIZE];
         let mut offset: usize = 0;
         // Set 8-byte discriminator.
         let discriminator: [u8; 8] = [221, 233, 49, 45, 181, 202, 220, 200];

--- a/programs/token/src/extensions/metadata.rs
+++ b/programs/token/src/extensions/metadata.rs
@@ -181,6 +181,15 @@ impl InitializeTokenMetadata<'_> {
     }
 
     pub fn invoke_signed(&self, signers: &[Signer]) -> ProgramResult {
+        // Instruction data layout:
+        // -  [0..8] [u8]: instruction discriminator
+        // -  [8..12] u32: name length (x1)
+        // -  [12..12+x1] [u8]: name string
+        // -  [12+x1..16+x1] u32: symbol length (x2)
+        // -  [16+x1..16+x1+x2] [u8]: symbol string
+        // -  [16+x1+x2..20+x1+x2] u32: uri length (x3)
+        // -  [20+x1+x2..20+x1+x2+x3][u8]: uri string
+
         // Allocate a buffer with max possible data length.
         let mut buf = [UNINIT_BYTE; 995];
         let mut offset: usize = 0;
@@ -273,6 +282,19 @@ impl UpdateField<'_> {
     }
 
     pub fn invoke_signed(&self, signers: &[Signer]) -> ProgramResult {
+        // Instruction data layout (if Field type is Key):
+        // -  [0..8] [u8]: instruction discriminator
+        // -  [8..9] u8: field enum type
+        // -  [9..13] u32: key length (x1)
+        // -  [13..13+x1] [u8]: key string
+        // -  [13+x1..17+x1] u32: value length (x2)
+        // -  [17+x1..17+x1+x2] [u8]: value string
+        // Instruction data layout (if Field type is not Key):
+        // -  [0..8] [u8]: instruction discriminator
+        // -  [8..9] u8: field enum type
+        // -  [9..13] u32: value length (x1)
+        // -  [13..13+x1] [u8]: value string
+
         // Allocate a buffer with max possible data length.
         let mut buf = [UNINIT_BYTE; 995];
         let mut offset: usize = 0;

--- a/programs/token/src/extensions/metadata.rs
+++ b/programs/token/src/extensions/metadata.rs
@@ -1,6 +1,15 @@
+use core::str;
+
 use super::{get_extension_data_bytes_for_variable_pack, BaseState, Extension, ExtensionType};
-use crate::TOKEN_2022_PROGRAM_ID;
-use pinocchio::{account_info::AccountInfo, program_error::ProgramError, pubkey::Pubkey};
+use crate::{write_bytes, TOKEN_2022_PROGRAM_ID, UNINIT_BYTE};
+use pinocchio::{
+    account_info::AccountInfo,
+    cpi::invoke_signed,
+    instruction::{AccountMeta, Instruction, Signer},
+    program_error::ProgramError,
+    pubkey::Pubkey,
+    ProgramResult,
+};
 
 /// State for Metadata for a token
 #[repr(C)]
@@ -41,7 +50,7 @@ impl TokenMetadata<'_> {
     /// the account data.
     #[inline(always)]
     pub fn from_account_info<'a>(
-        account_info: AccountInfo
+        account_info: AccountInfo,
     ) -> Result<TokenMetadata<'a>, ProgramError> {
         if account_info.data_len() < Self::SIZE_METADATA_LEN {
             return Err(ProgramError::InvalidAccountData);
@@ -53,10 +62,9 @@ impl TokenMetadata<'_> {
 
         let account_data = account_info.try_borrow_data()?;
 
-        let metadata_bytes = get_extension_data_bytes_for_variable_pack::<TokenMetadata>(
-            account_data.as_ref()
-        )
-            .ok_or(ProgramError::InvalidAccountData)?;
+        let metadata_bytes =
+            get_extension_data_bytes_for_variable_pack::<TokenMetadata>(account_data.as_ref())
+                .ok_or(ProgramError::InvalidAccountData)?;
 
         Self::from_bytes(metadata_bytes)
     }
@@ -73,44 +81,58 @@ impl TokenMetadata<'_> {
         offset += 32;
 
         let mint = unsafe { &*(data.as_ptr().add(offset) as *const [u8; 32]) };
-        
+
         offset += 32;
 
-        let name_len = &u32::from_le_bytes(unsafe { *(data.as_ptr().add(offset) as *const [u8; 4]) });
+        let name_len =
+            &u32::from_le_bytes(unsafe { *(data.as_ptr().add(offset) as *const [u8; 4]) });
 
         offset += 4;
 
-        let name = unsafe { core::str::from_utf8_unchecked(
-            core::slice::from_raw_parts(data.as_ptr().add(offset), *name_len as usize)
-        ) };
+        let name = unsafe {
+            core::str::from_utf8_unchecked(core::slice::from_raw_parts(
+                data.as_ptr().add(offset),
+                *name_len as usize,
+            ))
+        };
 
         offset += *name_len as usize;
 
-        let symbol_len = &u32::from_le_bytes(unsafe { *(data.as_ptr().add(offset) as *const [u8; 4]) });
+        let symbol_len =
+            &u32::from_le_bytes(unsafe { *(data.as_ptr().add(offset) as *const [u8; 4]) });
 
         offset += 4;
 
-        let symbol = unsafe { core::str::from_utf8_unchecked(
-            core::slice::from_raw_parts(data.as_ptr().add(offset), *symbol_len as usize)
-        ) };
+        let symbol = unsafe {
+            core::str::from_utf8_unchecked(core::slice::from_raw_parts(
+                data.as_ptr().add(offset),
+                *symbol_len as usize,
+            ))
+        };
 
         offset += *symbol_len as usize;
 
-        let uri_len = &u32::from_le_bytes(unsafe { *(data.as_ptr().add(offset) as *const [u8; 4]) });
+        let uri_len =
+            &u32::from_le_bytes(unsafe { *(data.as_ptr().add(offset) as *const [u8; 4]) });
 
         offset += 4;
 
-        let uri = unsafe { core::str::from_utf8_unchecked(
-            core::slice::from_raw_parts(data.as_ptr().add(offset), *uri_len as usize)
-        ) };
+        let uri = unsafe {
+            core::str::from_utf8_unchecked(core::slice::from_raw_parts(
+                data.as_ptr().add(offset),
+                *uri_len as usize,
+            ))
+        };
 
         offset += *uri_len as usize;
 
-        let additional_metadata_len = &u32::from_le_bytes(unsafe { *(data.as_ptr().add(offset) as *const [u8; 4]) });
+        let additional_metadata_len =
+            &u32::from_le_bytes(unsafe { *(data.as_ptr().add(offset) as *const [u8; 4]) });
 
         offset += 4;
 
-        let additional_metadata = unsafe { core::slice::from_raw_parts( data.as_ptr().add(offset), data.len() - offset) };
+        let additional_metadata =
+            unsafe { core::slice::from_raw_parts(data.as_ptr().add(offset), data.len() - offset) };
 
         Ok(TokenMetadata {
             update_authority: *update_authority,
@@ -131,4 +153,171 @@ impl Extension for TokenMetadata<'_> {
     const TYPE: ExtensionType = ExtensionType::TokenMetadata;
     const LEN: usize = Self::SIZE_METADATA_LEN;
     const BASE_STATE: BaseState = BaseState::Mint;
+}
+
+// Instructions
+pub struct InitializeTokenMetadata<'a> {
+    /// The mint that this metadata pointer is associated with
+    pub metadata: &'a AccountInfo,
+    /// The authority that can sign to update the metadata
+    pub update_authority: &'a AccountInfo,
+    /// The associated mint, used to counter spoofing to be sure that metadata
+    /// belongs to a particular mint
+    pub mint: &'a AccountInfo,
+    /// The account address that can update the mint
+    pub mint_authority: &'a AccountInfo,
+    /// The longer name of the token
+    pub name: &'a str,
+    /// The shortened symbol for the token
+    pub symbol: &'a str,
+    /// The URI pointing to richer metadata
+    pub uri: &'a str,
+}
+
+impl InitializeTokenMetadata<'_> {
+    #[inline(always)]
+    pub fn invoke(&self) -> ProgramResult {
+        self.invoke_signed(&[])
+    }
+
+    pub fn invoke_signed(&self, signers: &[Signer]) -> ProgramResult {
+        // Allocate a buffer with max possible data length.
+        let mut buf = [UNINIT_BYTE; 995];
+        let mut offset: usize = 0;
+
+        // Set 8-byte discriminator.
+        let discriminator: [u8; 8] = [210, 225, 30, 162, 88, 184, 77, 141];
+        write_bytes(&mut buf[offset..offset + 8], &discriminator);
+        offset += 8;
+
+        // Set name length, and name data bytes,
+        let name_bytes = self.name.as_bytes();
+        let name_len = name_bytes.len() as u32;
+        write_bytes(&mut buf[offset..offset + 4], &name_len.to_le_bytes());
+        offset += 4;
+        write_bytes(&mut buf[offset..offset + name_bytes.len()], name_bytes);
+        offset += name_bytes.len();
+
+        // Set symbol length, and symbol data bytes,
+        let symbol_bytes = self.symbol.as_bytes();
+        let symbol_len = symbol_bytes.len() as u32;
+        write_bytes(&mut buf[offset..offset + 4], &symbol_len.to_le_bytes());
+        offset += 4;
+        write_bytes(&mut buf[offset..offset + symbol_bytes.len()], symbol_bytes);
+        offset += symbol_bytes.len();
+
+        // Set uri length, and uri data bytes,
+        let uri_bytes = self.uri.as_bytes();
+        let uri_len = uri_bytes.len() as u32;
+        write_bytes(&mut buf[offset..offset + 4], &uri_len.to_le_bytes());
+        offset += 4;
+        write_bytes(&mut buf[offset..offset + uri_bytes.len()], uri_bytes);
+        offset += uri_bytes.len();
+
+        let account_metas: [AccountMeta; 4] = [
+            AccountMeta::writable(self.metadata.key()),
+            AccountMeta::readonly(self.update_authority.key()),
+            AccountMeta::readonly(self.mint.key()),
+            AccountMeta::readonly_signer(self.mint_authority.key()),
+        ];
+
+        // Prepare instruction with sliced buffer as data.
+        let instruction = Instruction {
+            program_id: &TOKEN_2022_PROGRAM_ID,
+            accounts: &account_metas,
+            data: unsafe { core::slice::from_raw_parts(buf.as_ptr() as _, offset) },
+        };
+
+        invoke_signed(&instruction, &[self.metadata, self.mint_authority], signers)
+    }
+}
+
+#[repr(u8)]
+pub enum Field<'a> {
+    /// The name field, corresponding to `TokenMetadata.name`
+    Name = 0,
+    /// The symbol field, corresponding to `TokenMetadata.symbol`
+    Symbol = 1,
+    /// The uri field, corresponding to `TokenMetadata.uri`
+    Uri = 2,
+    /// A user field, whose key is given by the associated string
+    Key(&'a str) = 3,
+}
+
+impl Field<'_> {
+    pub fn to_u8(&self) -> u8 {
+        match self {
+            Field::Name => 0,
+            Field::Symbol => 1,
+            Field::Uri => 2,
+            Field::Key(_) => 3,
+        }
+    }
+}
+
+pub struct UpdateField<'a> {
+    /// The mint that this metadata pointer is associated with
+    pub metadata: &'a AccountInfo,
+    /// The authority that can sign to update the metadata
+    pub update_authority: &'a AccountInfo,
+    /// Field to update in the metadata
+    pub field: Field<'a>,
+    /// Value to write for the field
+    pub value: &'a str,
+}
+
+impl UpdateField<'_> {
+    #[inline(always)]
+    pub fn invoke(&self) -> ProgramResult {
+        self.invoke_signed(&[])
+    }
+
+    pub fn invoke_signed(&self, signers: &[Signer]) -> ProgramResult {
+        // Allocate a buffer with max possible data length.
+        let mut buf = [UNINIT_BYTE; 995];
+        let mut offset: usize = 0;
+        // Set 8-byte discriminator.
+        let discriminator: [u8; 8] = [221, 233, 49, 45, 181, 202, 220, 200];
+        write_bytes(&mut buf[offset..offset + 8], &discriminator);
+        offset += 8;
+
+        write_bytes(&mut buf[offset..offset + 1], &[self.field.to_u8()]);
+        offset += 1;
+
+        // Set serialized key data in buffer if Field is Key type.
+        if let Field::Key(key) = self.field {
+            let key_bytes = key.as_bytes();
+            let key_len = key_bytes.len() as u32;
+            write_bytes(&mut buf[offset..offset + 4], &key_len.to_le_bytes());
+            offset += 4;
+            write_bytes(&mut buf[offset..offset + key_bytes.len()], key_bytes);
+            offset += key_bytes.len();
+        }
+
+        // Set serialized value data in buffer
+        let value_bytes = self.value.as_bytes();
+        let value_len = value_bytes.len() as u32;
+        write_bytes(&mut buf[offset..offset + 4], &value_len.to_le_bytes());
+        offset += 4;
+        write_bytes(&mut buf[offset..offset + value_bytes.len()], value_bytes);
+        offset += value_bytes.len();
+
+        let account_metas: [AccountMeta; 2] = [
+            AccountMeta::writable(self.metadata.key()),
+            AccountMeta::readonly_signer(self.update_authority.key()),
+        ];
+
+        // Prepare instruction with sliced buffer as data.
+        let instruction = Instruction {
+            program_id: &TOKEN_2022_PROGRAM_ID,
+            accounts: &account_metas,
+            data: unsafe { core::slice::from_raw_parts(buf.as_ptr() as _, offset) },
+        };
+
+        invoke_signed(
+            &instruction,
+            &[self.metadata, self.update_authority],
+            signers,
+        )
+    }
 }


### PR DESCRIPTION
Add InitializeTokenMetadata and UpdateField instructions for TokenMetadata Extensions.

Reference:
https://github.com/solana-program/token-metadata/blob/main/interface/src/instruction.rs